### PR TITLE
feat: add custom prompt template support for AI comment generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
+## [0.7.0] - 2025-09-08
+### Added
+- **Custom prompt template support:**
+  - New setting `dropcomments.promptTemplate` allows users to define a custom prompt for AI comment generation.
+  - Supports variables: `{language}`, `{code}`, `{style}`, `{emojiInstruction}`.
+  - If unset, the extension uses the default prompt logic.
 
+---
 
 ## [0.6.0] - 2025-09-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -77,6 +77,27 @@ DropComments supports routing AI requests to custom endpoints, enabling the use 
 
 **Security**: Only use trusted endpoints. Your code will be sent to the configured URL for comment generation.
 
+## Custom Prompt Template
+You can provide a custom prompt template for AI comment generation using the `dropcomments.promptTemplate` setting.
+
+- Leave empty to use the default prompt.
+- Supports variables:
+  - `{language}`: Language ID of the code
+  - `{code}`: Selected code
+  - `{style}`: Comment style instruction (succinct/detailed)
+  - `{emojiInstruction}`: Emoji usage instruction
+
+**Example template:**
+```
+You are an expert in {language}. Add comments to the following code:
+{style}
+{emojiInstruction}
+Code:
+{code}
+```
+
+Set your template in VS Code Settings > DropComments: Prompt Template.
+
 ## Features
 - Automatically generate code comments with AI assistance
 - Support for 20+ programming languages with appropriate comment syntax

--- a/docs/custom-prompt-template-prd.md
+++ b/docs/custom-prompt-template-prd.md
@@ -1,0 +1,101 @@
+# DropComments: Custom Prompt Template PRD
+
+## Feature Summary
+Allow users to define a custom prompt template for AI comment generation. If the user does not set a custom template, the extension will use its default prompt. This enables advanced users to tailor the AI’s instructions for their specific workflow, coding standards, or language.
+
+## User Stories
+
+- **As a user, I want to provide my own prompt template, so I can control how the AI generates comments for my code.**
+- **As a user, I want the extension to use my custom template if set, and fall back to the default prompt if not, so I always get useful comments.**
+- **As a user, I want to use variables in my template (e.g., language, code, style, emoji instructions), so my prompt is dynamic and context-aware.**
+- **As a user, I want to edit my template in VS Code settings, so I can easily experiment and refine my workflow.**
+
+## Acceptance Criteria
+
+- A new setting `dropcomments.promptTemplate` is available in VS Code settings.
+- If `dropcomments.promptTemplate` is set and non-empty, the extension uses it for AI comment generation.
+- If the setting is empty or unset, the extension uses its default prompt logic.
+- The template supports variables for substitution:
+  - `{language}`: Language ID of the code
+  - `{code}`: Selected code
+  - `{style}`: Comment style instruction (succinct/detailed)
+  - `{emojiInstruction}`: Emoji usage instruction
+- Documentation is updated to describe how to use and format custom templates.
+- No breaking changes to existing functionality; users who do not set a custom template experience the same behavior as before.
+
+## Goals & Non-Goals
+
+**Goals:**
+- Empower users to customize the AI prompt for comment generation.
+- Support variable substitution for context-aware templates.
+- Maintain a robust default prompt for users who do not customize.
+
+**Non-Goals:**
+- No support for multiple templates or per-language templates in this iteration.
+- No UI for previewing or validating template output.
+- No advanced scripting or conditional logic in templates.
+
+## Scope
+
+- In scope: New setting, template substitution logic, documentation.
+- Out of scope: UI preview, template validation, multi-template management.
+
+## UX Details
+
+- Setting name: `DropComments: Prompt Template`
+- Setting key: `dropcomments.promptTemplate`
+- Type: string (multi-line supported)
+- Location: Settings > Extensions > DropComments
+- Behavior: Uses custom template if set, otherwise defaults.
+
+## Dependencies & Constraints
+
+- Template must be a string; variable names are fixed.
+- If the template is invalid or missing variables, the extension will still attempt to substitute what it can.
+- No impact on API key, model, or endpoint settings.
+
+## Error Handling & Edge Cases
+
+- Empty or unset template: use default prompt.
+- Invalid variable names: ignored, no error.
+- Malformed template: use as-is, no validation.
+
+## Security & Privacy
+
+- No additional secrets or sensitive data stored.
+- User is responsible for the content of their template.
+
+## Performance
+
+- Negligible overhead for string substitution.
+
+## Test Plan
+
+- Set a custom template and verify it is used for comment generation.
+- Leave the template empty and verify the default prompt is used.
+- Use all supported variables and confirm correct substitution.
+- Use unsupported variables and confirm they are ignored.
+- Validate fallback and error handling.
+
+## Rollout & Documentation
+
+- Version bump: minor.
+- README: Add section on custom prompt templates with example.
+- CHANGELOG: Announce new setting and its purpose.
+
+## Success Metrics
+
+- Qualitative: Users can successfully customize the prompt and see the effect in generated comments.
+- Support signals: Positive feedback on flexibility; minimal confusion or support requests.
+
+## Risks & Mitigations
+
+- Risk: Users expect advanced logic or validation in templates.
+  - Mitigation: Clearly document limitations and provide examples.
+- Risk: Malformed templates lead to poor AI output.
+  - Mitigation: Default fallback and clear documentation.
+
+## Open Questions
+
+- Should we support per-language or per-workspace templates in the future?
+- Should we add a UI preview for template output?

--- a/docs/custom-prompt-template-techspec.md
+++ b/docs/custom-prompt-template-techspec.md
@@ -1,0 +1,119 @@
+# DropComments: Custom Prompt Template — Technical Specification
+
+## Overview
+Enable a configurable prompt template for AI-driven comment generation. When users provide a custom template, it replaces the default prompt. If left empty, the extension uses the existing default prompt. This feature is additive, preserves current workflows, and supports simple variable substitution to keep prompts context-aware.
+
+## Objectives (traceable to PRD)
+- New setting `dropcomments.promptTemplate` (string; default empty) available in Settings.
+- If set (non-empty after trim), the custom template is used for the AI prompt.
+- If unset/empty, the default prompt builder is used without behavior change.
+- Variable substitution supported:
+  - `{language}` → active document language ID
+  - `{code}` → selected code (post-truncation, if applicable)
+  - `{style}` → instruction derived from `dropcomments.commentStyle`
+  - `{emojiInstruction}` → instruction derived from `dropcomments.useEmojis`
+- Documentation updated (README and CHANGELOG).
+
+## Non-Goals
+- Advanced templating (conditionals/loops), validation UI, or multiple/per-language templates.
+- Any changes to model selection, API endpoints, or error classification.
+
+## Assumptions
+- The default AI provider (OpenAI-compatible) will accept arbitrary prompt text.
+- Workspace trust enforcement remains unchanged before making network calls.
+- Templates are provided by the user as plain text and are not executable.
+
+## Inputs, Outputs, and Contracts
+- Inputs
+  - Editor selection (text) and language ID
+  - Settings: `promptTemplate`, `commentStyle` (succinct/detailed), `useEmojis` (boolean), and existing `model`, `apiKey`, `apiUrl` (if any)
+- Output
+  - Model response expected to be the original code with comments inserted (unchanged contract)
+- Error Modes
+  - Missing API key, network errors, provider errors → handled by existing paths
+  - Empty/whitespace template → silently falls back to default prompt
+- Success Criteria
+  - With non-empty template, prompt uses correct substitutions
+  - With empty/unset template, behavior identical to current release
+
+## Architecture & Integration Points
+- Prompt Builder Logic
+  - Centralize prompt creation behind a single function that first reads `promptTemplate`.
+  - If template is provided and non-empty, apply substitutions and return the result.
+  - Otherwise, return the default prompt built from current logic.
+- Settings Retrieval
+  - Read `promptTemplate` at prompt-build time alongside `commentStyle` and `useEmojis` for consistent state.
+- Command Paths
+  - No changes: both Command Palette and editor context menu call the same handler and thus share prompt behavior.
+
+## Variable Substitution Rules
+- Exact token names with braces: `{language}`, `{code}`, `{style}`, `{emojiInstruction}`.
+- Global replacement for each token; unknown tokens remain intact.
+- `{style}` mapping:
+  - succinct → “Keep comments succinct and focused only on key logic.”
+  - detailed → “Make comments more detailed and explanatory, including rationale and context where helpful.”
+- `{emojiInstruction}` mapping:
+  - useEmojis = true → “You MAY add occasional emojis in comments (never inside string literals or code).”
+  - useEmojis = false → “Do not use emojis.”
+
+## Validation & Fallback
+- Template is considered unset if empty or whitespace-only after trim.
+- No structural validation beyond string substitution; unknown variables are ignored.
+- If `{code}` is omitted by the user’s template, the AI may have insufficient context; document as a caveat (no hard error).
+
+## Security & Privacy
+- Do not log entire prompts or code in output channels.
+- No new secrets added; trust and key handling unchanged.
+- Respect workspace trust gating for all AI operations.
+
+## Performance
+- Negligible: minor string reads/replacements compared to existing workflow.
+
+## Backward Compatibility
+- Users without a configured template see no change in behavior.
+- No changes to activation events, command names, or existing settings beyond introducing the new setting.
+
+## Test Strategy
+- Unit Tests
+  - Substitution: all supported tokens replaced; unsupported tokens remain.
+  - Fallback: empty/whitespace-only template uses default prompt.
+  - Style/emoji mapping correctness for `{style}` and `{emojiInstruction}`.
+- Integration Tests
+  - With custom template set: ensure AI call receives the substituted prompt (via interception/mocking where feasible).
+  - Parity across invocation paths (Command Palette vs context menu).
+  - Large selection truncation continues to work before substitution for `{code}`.
+- Manual QA
+  - Custom template with all variables → verify meaningful output.
+  - Template missing `{code}` → verify stability and document caveat.
+  - Toggle `useEmojis` and switch styles to see mapped values reflected.
+
+## Rollout & Documentation
+- Version bump: minor.
+- README: Add a “Custom Prompt Template” section with variables table and an example template.
+- CHANGELOG: Add entry in “Added” for the new setting and behavior.
+
+## Risks & Mitigations
+- Users expect advanced templating features → Document scope (simple variables only) and provide examples.
+- Poor outcomes from malformed templates → Document best practices and caveats (especially inclusion of `{code}`).
+- Prompt injection via template text → Remind users they fully control template content.
+
+## Implementation Guide (Step-by-Step)
+1. Manifest
+   - Add `dropcomments.promptTemplate` under contributes.configuration with proper title, description, default empty, and scope application.
+2. Prompt Builder
+   - Read `promptTemplate`, `commentStyle`, and `useEmojis`.
+   - If `promptTemplate` non-empty, build substitution map and apply global replacements for `{language}`, `{code}`, `{style}`, `{emojiInstruction}`.
+   - Else, construct and return the default prompt as done today.
+3. Logging
+   - Avoid logging the full prompt or code; retain minimal status logs only.
+4. Documentation
+   - README: Add section with example and variables; reference caveats (e.g., include `{code}`).
+   - CHANGELOG: Note the new setting and its default behavior.
+5. Testing
+   - Add and run unit + integration tests per strategy above.
+
+## Quality Gates
+- Build passes (TypeScript compile).
+- Lint passes (ESLint) with no new issues for this feature.
+- Unit/integration tests pass.
+- Manual smoke test using a simple multi-line template that includes all variables.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dropcomments",
   "displayName": "DropComments",
   "description": "DropComments is a Visual Studio Code extension that helps you automatically add comments to your code using AI.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "icon": "img/DropCommentsLogo.png",
   "repository": {
     "type": "git",
@@ -69,6 +69,13 @@
           "type": "string",
           "default": "",
           "description": "Optional base URL for the AI API (OpenAI-compatible). Leave empty to use the default OpenAI endpoint.",
+          "scope": "application"
+        }
+        ,
+        "dropcomments.promptTemplate": {
+          "type": "string",
+          "default": "",
+          "description": "Custom prompt template for AI comment generation. Supports variables: {language}, {code}, {style}, {emojiInstruction}. Leave empty to use the default template.",
           "scope": "application"
         }
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,36 +87,49 @@ class AIClient {
 		}
 	}
 
-	private buildPrompt(language: string, selectedCode: string, useEmojis: boolean, commentStyle: string): string {
-		const emojiInstruction = useEmojis
-			? "You MAY add occasional emojis in comments (never inside string literals or code)."
-			: "Do not use emojis.";
+	   private buildPrompt(language: string, selectedCode: string, useEmojis: boolean, commentStyle: string): string {
+		   const config = vscode.workspace.getConfiguration('dropcomments');
+		   const customTemplate = config.get<string>('promptTemplate', '');
 
-		let styleInstruction = "";
-		if (commentStyle === "detailed") {
-			styleInstruction = "Make comments more detailed and explanatory, including rationale and context where helpful.";
-		} else {
-			styleInstruction = "Keep comments succinct and focused only on key logic.";
-		}
+		   const emojiInstruction = useEmojis
+			   ? "You MAY add occasional emojis in comments (never inside string literals or code)."
+			   : "Do not use emojis.";
 
-		return [
-			"You are a senior developer helping document code.",
-			`Add clear, concise ${language} comments to the provided code.`,
-			styleInstruction,
-			"Comment ONLY where it adds value.",
-			"Comment ONLY key logic and complex sections.",
-			"Return the ORIGINAL code with comments inserted.",
-			"Do NOT wrap the entire selection in a single comment block.",
-			"Do NOT remove or reorder code.",
-			"Do NOT comment out executable code lines.",
-			"Use inline trailing comments sparingly; prefer preceding line comments for multi-line logic.",
-			emojiInstruction,
-			"Return ONLY the code (no markdown fences, no explanations outside comments).",
-			"",
-			"Code:",
-			selectedCode
-		].join('\n');
-	}
+		   let styleInstruction = "";
+		   if (commentStyle === "detailed") {
+			   styleInstruction = "Make comments more detailed and explanatory, including rationale and context where helpful.";
+		   } else {
+			   styleInstruction = "Keep comments succinct and focused only on key logic.";
+		   }
+
+		   if (customTemplate && customTemplate.trim()) {
+			   // Replace variables in the template
+			   return customTemplate
+				   .replace(/{language}/g, language)
+				   .replace(/{code}/g, selectedCode)
+				   .replace(/{style}/g, styleInstruction)
+				   .replace(/{emojiInstruction}/g, emojiInstruction);
+		   }
+
+		   // Default prompt logic
+		   return [
+			   "You are a senior developer helping document code.",
+			   `Add clear, concise ${language} comments to the provided code.`,
+			   styleInstruction,
+			   "Comment ONLY where it adds value.",
+			   "Comment ONLY key logic and complex sections.",
+			   "Return the ORIGINAL code with comments inserted.",
+			   "Do NOT wrap the entire selection in a single comment block.",
+			   "Do NOT remove or reorder code.",
+			   "Do NOT comment out executable code lines.",
+			   "Use inline trailing comments sparingly; prefer preceding line comments for multi-line logic.",
+			   emojiInstruction,
+			   "Return ONLY the code (no markdown fences, no explanations outside comments).",
+			   "",
+			   "Code:",
+			   selectedCode
+		   ].join('\n');
+	   }
 
 	async generateComments(language: string, selectedCode: string, useEmojis: boolean, model: string, commentStyle: string): Promise<string> {
 		this.updateClient();


### PR DESCRIPTION
- Introduced a new setting `dropcomments.promptTemplate` allowing users to define a custom prompt for AI comment generation in the extension.
- The custom template supports variables: `{language}`, `{code}`, `{style}`, and `{emojiInstruction}` for dynamic and context-aware prompts.
- Updated `README.md` to include instructions on using the custom prompt template.
- Modified `CHANGELOG.md` to reflect the addition of this feature.
- Enhanced `extension.ts` to utilize the custom template if set, falling back to the default prompt logic if not.
- Added tests in `extension.test.ts` to ensure the correct functionality of the custom prompt template and its variable substitution.

This feature empowers users to tailor AI-generated comments to their specific coding standards and workflows.